### PR TITLE
Bump sifter to ^0.5.1 for updated microtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "microplugin": "0.0.3",
-    "sifter": "^0.4.0"
+    "sifter": "^0.5.1"
   },
   "devDependencies": {
     "grunt": "0.4.x",


### PR DESCRIPTION
The old version of sifter currently used in this package references an
old version of microtime that doesn't compile anymore.

Newer versions of sifter use either updates versions of microtime, or
omit the dependency altogether.